### PR TITLE
feat: mouseLeaveDelayInSeconds option for desktop

### DIFF
--- a/apps/web/docs/settings/desktop.mdx
+++ b/apps/web/docs/settings/desktop.mdx
@@ -10,7 +10,8 @@ title: desktop
 
 - **triggerOnIdle** - if true, the handlers will be triggered when the user is idle
 - **triggerOnMouseLeave** - if true, the handlers will be triggered when the user is about to leave your website
-- **delayInSecondsToTrigger** - delay in seconds to trigger the exit intent handlers. **triggerOnIdle** **must be true**!
+- **delayInSecondsToTrigger** - delay in seconds to trigger the exit intent handlers on idle. **triggerOnIdle** **must be true**!
+- **mouseLeaveDelayInSeconds** - delay in seconds to trigger the exit intent handlers on mouse leave. **triggerOnMouseLeave** **must be true**!
 - **useBeforeUnload** - if true, the handlers will be triggered when the user is about to leave your website. **UI will be blocked until the user cancels the action**.
 
 <br/>
@@ -18,6 +19,7 @@ title: desktop
 ## Default
 ```tsx
 delayInSecondsToTrigger: 10
+mouseLeaveDelayInSeconds: 5
 triggerOnMouseLeave: true
 triggerOnIdle: false
 useBeforeUnload: false
@@ -30,6 +32,7 @@ useBeforeUnload: false
 useExitIntent({
   desktop: {
     delayInSecondsToTrigger: 10,
+    mouseLeaveDelayInSeconds: 5,
     triggerOnMouseLeave: true,
     triggerOnIdle: false
     useBeforeUnload: false

--- a/apps/web/src/shared/constants/codes.ts
+++ b/apps/web/src/shared/constants/codes.ts
@@ -35,7 +35,8 @@ export const codes = {
           "triggerOnIdle": false,
           "useBeforeUnload": false,
           "triggerOnMouseLeave": true,
-          "delayInSecondsToTrigger": 10
+          "delayInSecondsToTrigger": 10,
+          "mouseLeaveDelayInSeconds": 5
         },
 
         "mobile": {

--- a/apps/web/src/templates/Home/Playground/index.tsx
+++ b/apps/web/src/templates/Home/Playground/index.tsx
@@ -158,6 +158,21 @@ export function PlaygroundSection() {
             </Label>
 
             <Label>
+              mouseLeaveDelayInSeconds:
+              <input
+                defaultValue={settings?.desktop?.mouseLeaveDelayInSeconds}
+                type="number"
+                onChange={({ target }) => {
+                  updateSettings({
+                    desktop: {
+                      mouseLeaveDelayInSeconds: target.valueAsNumber,
+                    },
+                  })
+                }}
+              />
+            </Label>
+            
+            <Label>
               useBeforeUnload:
               <input
                 checked={settings?.desktop?.useBeforeUnload}

--- a/apps/web/src/templates/Home/Playground/index.tsx
+++ b/apps/web/src/templates/Home/Playground/index.tsx
@@ -171,7 +171,7 @@ export function PlaygroundSection() {
                 }}
               />
             </Label>
-            
+
             <Label>
               useBeforeUnload:
               <input

--- a/packages/use-exit-intent/src/index.ts
+++ b/packages/use-exit-intent/src/index.ts
@@ -165,7 +165,6 @@ export function useExitIntent(props: ExitIntentSettings | void = {}) {
       }
 
       if (isMobile() && mobile?.triggerOnIdle) {
-        removeIdleEvents(execute)
         createIdleEvents(execute)
       }
 

--- a/packages/use-exit-intent/src/index.ts
+++ b/packages/use-exit-intent/src/index.ts
@@ -46,7 +46,6 @@ export function useExitIntent(props: ExitIntentSettings | void = {}) {
 
   const [isTriggered, setIsTriggered] = useState(false)
   const [isUnsubscribed, setIsUnsubscribed] = useState(false)
-  const [isMouseLeaveDetectionEnabled, setIsMouseLeaveDetectionEnabled] = useState(false)
 
   const handlers = useRef<ExitIntentHandler[]>([]).current
   const shouldNotTrigger = useRef<boolean>(false)

--- a/packages/use-exit-intent/src/types/index.ts
+++ b/packages/use-exit-intent/src/types/index.ts
@@ -12,6 +12,7 @@ export interface DesktopOptions {
   triggerOnMouseLeave?: boolean
   delayInSecondsToTrigger?: number
   useBeforeUnload?: boolean
+  mouseLeaveDelayInSeconds?: number
 }
 
 export interface MobileOptions {

--- a/packages/use-exit-intent/src/utils/constants.ts
+++ b/packages/use-exit-intent/src/utils/constants.ts
@@ -12,12 +12,12 @@ export const defaultSettings: InternalExitIntentSettings = {
     daysToExpire: 30,
     key: 'exit-intent',
   },
-
   desktop: {
     triggerOnIdle: false,
     useBeforeUnload: false,
     triggerOnMouseLeave: true,
     delayInSecondsToTrigger: 10,
+    mouseLeaveDelayInSeconds: 5,
   },
 
   mobile: {


### PR DESCRIPTION
- Added `mouseLeaveDelayInSeconds` to the `DesktopOptions` interface
- Implemented a timer to enable mouse leave detection after the specified delay
- Updated the `useEffect` hook to handle the new behavior

This change helps prevent premature triggering of exit intent actions, especially useful for pages with longer load times or when users might accidentally move their mouse outside the window shortly after page load.

***Example***
```
const { settings, isTriggered, unsubscribe } = useExitIntent({
  desktop: {
    triggerOnMouseLeave: true,
    mouseLeaveDelayInSeconds: 5 // Start detecting mouse leave 5 seconds after page load
  }
})
```